### PR TITLE
fix: Exclude database name from active check.

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -67,10 +67,15 @@ module ActiveRecord
           end
         end
 
-        def do_execute(sql, name = nil, format: 'JSONCompact', settings: {})
+        def do_execute(sql, name = nil, format: 'JSONCompact', settings: {}, exclude_database: false)
           log(sql, "#{adapter_name} #{name}") do
             formatted_sql = apply_format(sql, format)
             request_params = @config || {}
+
+            if exclude_database
+              request_params = request_params.except(:database)
+            end
+
             res = @connection.post("/?#{request_params.merge(settings).to_param}", formatted_sql, 'User-Agent' => "Clickhouse ActiveRecord #{ClickhouseActiverecord::VERSION}")
 
             process_response(res)

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -153,7 +153,7 @@ module ActiveRecord
       def active?
         # Matches Postgres' implementation.
         @lock.synchronize do
-          do_execute("SELECT 1", format: nil)
+          do_execute("SELECT 1", format: nil, exclude_database: true)
         end
 
         true


### PR DESCRIPTION
The `active?` call fails before we create the database otherwise.